### PR TITLE
Add *-and-up sizing for all breakpoints

### DIFF
--- a/_generic.helpers.scss
+++ b/_generic.helpers.scss
@@ -21,13 +21,19 @@
 /// @type List [default]
 /// @todo n/a
 $breakpoints: (
-    "palm"          "screen and (max-width: 44.9375em)",
-    "lap"           "screen and (min-width: 45em) and (max-width: 63.9375em)",
-    "lap-and-up"    "screen and (min-width: 45em)",
-    "portable"      "screen and (max-width: 63.9375em)",
-    "desk"          "screen and (min-width: 64em)",
-    "retina"        "(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)"
+    "palm"             "screen and (max-width: 44.9375em)",
+    "palm-and-up"      "screen and (min-width: 44.9375em)",
+    "lap"              "screen and (min-width: 45em) and (max-width: 63.9375em)",
+    "lap-and-up"       "screen and (min-width: 45em)",
+    "portable"         "screen and (max-width: 63.9375em)",
+    "portable-and-up"  "screen and (min-width: 63.9375em)",
+    "desk"             "screen and (min-width: 64em)",
+    "desk-and-up"      "screen and (min-width: 64em)",
+    "retina"           "(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)"
 ) !default;
+// @NOTE: The desk-and-up breakpoint is the same as desk, but is useful to keep
+// the same naming convention for SIZE-and-up that the other breakpoints use
+// when defining a min-width query
 
 /// @name media-query
 /// @output Generates whole media queries from the breakpoints defined above


### PR DESCRIPTION
The current breakpoints are a mix of queries that detect if 
1. the viewport is smaller than the specified size (e.g. `portable` checks if the screen is smaller than the portable size), 
2. the viewport is between two specified sizes (e.g. `lap` checks if the screen is between palm and portable size)
3. the viewport is larger then the specified size (e.g. `desk` checks if the screen is larger than desktop size)

This makes it pretty hard to write responsive CSS using these breakpoints without constantly referring to their definitions. An easier way that many systems use is to define styles for the smallest screen size desired first, then use min-width queries (e.g. this size or larger) to change styles as the viewport grows.

This allows developers to only change styles for a particular class or element when it it necessary to do so, e.g. resizing a navbar above lap size only and text above palm size only.

To support this use case, I've translated all the breakpoints to include a SIZE-and-up option. I kept backwards compat by not changing the existing breakpoints at all, so developers can continue to rely on them the same way.

Here's how the new breakpoints could be used:

```
.app-shell {
  display: block;
  padding: 1rem;
  @include media-query(palm-and-up) {
    /* Bump the padding slightly on screen sizes above palm */
    padding: 1.25rem;
  }
  @include media-query(desk-and-up) {
    /* Bump the padding more on screen sizes above desktop */
    padding: 2rem;
    /* Use flex on screen sizes above desktop to show children in columns */
    display: flex;
  }
}
```

cc @Menkhaus-ge @randyaskin for review. I'll make a parallel PR in px-viewport-design to match this to keep backwards compat.